### PR TITLE
Updated compose, kotlin, dagger, androidx libraries

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,16 +1,16 @@
 [versions]
-compose = "1.1.0"
-composeCompiler = "1.1.0"
-dagger = "2.41"
-kotlin = "1.6.10"
+compose = "1.2.1"
+composeCompiler = "1.3.0"
+dagger = "2.43.2"
+kotlin = "1.7.10"
 autoService = "1.0.1"
 incap = "0.3"
 javapoet = "1.13.0"
 espresso = "3.4.0"
 androidXTest = "1.4.0"
-compileSdk = "31"
+compileSdk = "32"
 minSdk = "21"
-targetSdk = "30"
+targetSdk = "32"
 spotless = "6.3.0"
 dependencyUpdates = "0.42.0"
 
@@ -19,15 +19,15 @@ spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 dependencyUpdates = { id = "com.github.ben-manes.versions", version.ref = "dependencyUpdates" }
 
 [libraries]
-androidx-activityCompose = "androidx.activity:activity-compose:1.4.0"
-androidx-appcompat = "androidx.appcompat:appcompat:1.4.1"
-androidx-lifecycle-livedata = "androidx.lifecycle:lifecycle-livedata-ktx:2.4.1"
+androidx-activityCompose = "androidx.activity:activity-compose:1.5.1"
+androidx-appcompat = "androidx.appcompat:appcompat:1.5.0"
+androidx-lifecycle-livedata = "androidx.lifecycle:lifecycle-livedata-ktx:2.5.1"
 
 compose-ui = { module = "androidx.compose.ui:ui", version.ref = "compose" }
 compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "compose" }
 compose-material = { module = "androidx.compose.material:material", version.ref = "compose" }
 compose-runtime-livedata = { module = "androidx.compose.runtime:runtime-livedata", version.ref = "compose" }
-compose-navigation = "androidx.navigation:navigation-compose:2.4.1"
+compose-navigation = "androidx.navigation:navigation-compose:2.5.1"
 
 dagger-runtime = { module = "com.google.dagger:dagger", version.ref = "dagger" }
 dagger-compiler = { module = "com.google.dagger:dagger-compiler", version.ref = "dagger" }
@@ -50,7 +50,7 @@ espresso-orchestrator = "androidx.test:orchestrator:1.4.1"
 compose-testing = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "compose" }
 
 # Gradle plugins
-plugin-androidTools = "com.android.tools.build:gradle:7.1.1"
+plugin-androidTools = "com.android.tools.build:gradle:7.2.2"
 plugin-hiltAndroidGradle = { module = "com.google.dagger:hilt-android-gradle-plugin", version.ref = "dagger" }
 plugin-kotlinGradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 plugin-mavenPublish = "com.vanniktech:gradle-maven-publish-plugin:0.18.0"


### PR DESCRIPTION
Some libraries are dependent on each-other, so renovate isn't working for now