### PR TITLE
Removed dependency updates plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,3 @@
-import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 buildscript {
@@ -16,7 +15,6 @@ buildscript {
 
 plugins {
   alias(libs.plugins.spotless)
-  alias(libs.plugins.dependencyUpdates)
 }
 
 spotless {
@@ -52,23 +50,6 @@ spotless {
     trimTrailingWhitespace()
     endWithNewline()
     targetExclude("**/build/**")
-  }
-}
-
-fun isStable(version: String): Boolean {
-  val stableKeyword = listOf("RELEASE", "FINAL", "GA").any { version.toUpperCase().contains(it) }
-  val regex = "^[0-9,.v-]+(-r)?$".toRegex()
-  val isStable = stableKeyword || regex.matches(version)
-  return isStable
-}
-
-tasks.named("dependencyUpdates", DependencyUpdatesTask::class.java) {
-  rejectVersionIf {
-    if (isStable(currentVersion)) {
-      !isStable(candidate.version)
-    } else {
-      false
-    }
   }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,11 +11,9 @@ compileSdk = "33"
 minSdk = "21"
 targetSdk = "33"
 spotless = "6.18.0"
-dependencyUpdates = "0.46.0"
 
 [plugins]
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
-dependencyUpdates = { id = "com.github.ben-manes.versions", version.ref = "dependencyUpdates" }
 
 [libraries]
 androidx-activityCompose = "androidx.activity:activity-compose:1.7.0"


### PR DESCRIPTION
This is no longer needed as Android Studio has support for TOML files, and renovate is doing automatic version updates